### PR TITLE
chore: bumps arquillian core to latest release

### DIFF
--- a/core/src/main/java/io/github/zforgo/arquillian/junit5/ArquillianExtension.java
+++ b/core/src/main/java/io/github/zforgo/arquillian/junit5/ArquillianExtension.java
@@ -1,5 +1,10 @@
 package io.github.zforgo.arquillian.junit5;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.function.Predicate;
+
 import io.github.zforgo.arquillian.junit5.extension.RunModeEvent;
 import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
@@ -14,11 +19,6 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ExceptionUtils;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, InvocationInterceptor, TestExecutionExceptionHandler {
 	private static final String CHAIN_EXCEPTION_MESSAGE_PREFIX = "Chain of InvocationInterceptors never called invocation";
@@ -96,6 +96,11 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
 
 	private void interceptInvocation(ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
 		TestResult result = getManager(extensionContext).getAdaptor().test(new TestMethodExecutor() {
+			@Override
+			public String getMethodName() {
+				return extensionContext.getRequiredTestMethod().getName();
+			}
+
 			@Override
 			public Method getMethod() {
 				return extensionContext.getRequiredTestMethod();

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<arquillian.version>1.4.1.Final</arquillian.version>
+		<arquillian.version>1.5.0.Final</arquillian.version>
 		<version.junit5>5.5.1</version.junit5>
 		<version.junit5.platform>1.5.1</version.junit5.platform>
 		<version.shrinkwrap_shrinkwrap>1.2.6</version.shrinkwrap_shrinkwrap>


### PR DESCRIPTION
First and foremost I must say I'm thrilled to see this work taking shape. Thank you very much for making this happen. Would you be interested in contributing it to the upstream core in the nearest future? Happy to collaborate on that!

#### About this PR

Latest Arquillian Core `1.5.0.Final` brings improvement for JUnit-based test frameworks and exposes test method name, which in Frameworks like Spock, can be a textual description (logical name) rather than actual method name. See more in the related PR https://github.com/arquillian/arquillian-core/pull/215

This PR adjusts the implementation by providing new method.